### PR TITLE
Hide illustration captions

### DIFF
--- a/style.css
+++ b/style.css
@@ -208,6 +208,15 @@ button {
   width: min(100%, 260px);
 }
 
+#imageLabel,
+#imageCaption,
+.card-label,
+.card-caption,
+.figure-label,
+.figure-caption {
+  display: none !important;
+}
+
 .speech-area {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- hide illustration-related labels and captions so artwork no longer spoils the answer

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8ffa4f91c8330915f17178f217f60