### PR TITLE
Add illustrations and mapping for all quiz words

### DIFF
--- a/assets/ame.svg
+++ b/assets/ame.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
+  <rect width="320" height="240" fill="#577590" rx="24" />
+  <g fill="#ADE8F4">
+    <ellipse cx="90" cy="120" rx="14" ry="20" />
+    <ellipse cx="140" cy="160" rx="12" ry="18" />
+    <ellipse cx="200" cy="110" rx="10" ry="16" />
+    <ellipse cx="240" cy="150" rx="13" ry="19" />
+  </g>
+  <text x="50%" y="82%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="52" fill="#fff">あめ</text>
+</svg>

--- a/assets/hoshi.svg
+++ b/assets/hoshi.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
+  <rect width="320" height="240" fill="#3D348B" rx="24" />
+  <polygon points="160,70 175,118 226,118 185,148 199,196 160,168 121,196 135,148 94,118 145,118" fill="#FEE440" />
+  <text x="50%" y="85%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="48" fill="#fff">ほし</text>
+</svg>

--- a/assets/kame.svg
+++ b/assets/kame.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
+  <rect width="320" height="240" fill="#457B9D" rx="24" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="64" fill="#fff">かめ</text>
+</svg>

--- a/assets/kaze.svg
+++ b/assets/kaze.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
+  <rect width="320" height="240" fill="#8ECAE6" rx="24" />
+  <path d="M60 120h140c15 0 28-10 28-22s-13-22-28-22" fill="none" stroke="#023047" stroke-width="12" stroke-linecap="round" />
+  <path d="M90 160h110c12 0 22-8 22-18s-10-18-22-18" fill="none" stroke="#023047" stroke-width="12" stroke-linecap="round" opacity="0.8" />
+  <text x="50%" y="80%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="52" fill="#023047">かぜ</text>
+</svg>

--- a/assets/kuma.svg
+++ b/assets/kuma.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
+  <rect width="320" height="240" fill="#F4A261" rx="24" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="64" fill="#fff">くま</text>
+</svg>

--- a/assets/mizu.svg
+++ b/assets/mizu.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
+  <rect width="320" height="240" fill="#48CAE4" rx="24" />
+  <path d="M160 60c30 40 60 70 60 100a60 60 0 0 1-120 0c0-30 30-60 60-100z" fill="#023E8A" opacity="0.7" />
+  <text x="50%" y="82%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="52" fill="#fff">みず</text>
+</svg>

--- a/assets/mushi.svg
+++ b/assets/mushi.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
+  <rect width="320" height="240" fill="#2D6A4F" rx="24" />
+  <circle cx="130" cy="120" r="28" fill="#95D5B2" />
+  <circle cx="190" cy="120" r="24" fill="#95D5B2" />
+  <rect x="150" y="80" width="20" height="80" rx="10" fill="#40916C" />
+  <text x="50%" y="85%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="48" fill="#fff">むし</text>
+</svg>

--- a/assets/saru.svg
+++ b/assets/saru.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
+  <rect width="320" height="240" fill="#E76F51" rx="24" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="64" fill="#fff">さる</text>
+</svg>

--- a/assets/shika.svg
+++ b/assets/shika.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
+  <rect width="320" height="240" fill="#F6BD60" rx="24" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="64" fill="#4D331F">しか</text>
+</svg>

--- a/assets/suna.svg
+++ b/assets/suna.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
+  <rect width="320" height="240" fill="#FFB703" rx="24" />
+  <path d="M40 180c40-40 80-60 120-60s80 20 120 60v20H40z" fill="#E9C46A" />
+  <text x="50%" y="70%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="56" fill="#8D5524">すな</text>
+</svg>

--- a/assets/tsuki.svg
+++ b/assets/tsuki.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
+  <rect width="320" height="240" fill="#2D5D8F" rx="24" />
+  <circle cx="220" cy="100" r="60" fill="#FEE440" opacity="0.9" />
+  <text x="50%" y="70%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="56" fill="#fff">つき</text>
+</svg>

--- a/assets/ushi.svg
+++ b/assets/ushi.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
+  <rect width="320" height="240" fill="#2A9D8F" rx="24" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="64" fill="#fff">うし</text>
+</svg>

--- a/assets/yama.svg
+++ b/assets/yama.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
+  <rect width="320" height="240" fill="#84A59D" rx="24" />
+  <polygon points="40,200 120,80 200,200" fill="#52796F" />
+  <polygon points="120,200 200,90 280,200" fill="#354F52" opacity="0.85" />
+  <text x="50%" y="75%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="56" fill="#fff">やま</text>
+</svg>

--- a/assets/yuki.svg
+++ b/assets/yuki.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
+  <rect width="320" height="240" fill="#B5E48C" rx="24" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="64" fill="#1B4332">ゆき</text>
+</svg>

--- a/assets/yume.svg
+++ b/assets/yume.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
+  <rect width="320" height="240" fill="#9D4EDD" rx="24" />
+  <circle cx="90" cy="90" r="26" fill="#FDE2FF" opacity="0.8" />
+  <circle cx="130" cy="60" r="18" fill="#FDE2FF" opacity="0.7" />
+  <circle cx="200" cy="90" r="22" fill="#FDE2FF" opacity="0.75" />
+  <text x="50%" y="80%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="52" fill="#fff">ゆめ</text>
+</svg>

--- a/main.js
+++ b/main.js
@@ -30,9 +30,24 @@ const PLACEHOLDER_IMAGE = {
 const WORD_IMAGE_MAP = {
   ねこ: 'neko',
   いぬ: 'inu',
+  くま: 'kuma',
+  さる: 'saru',
   かに: 'kani',
+  うし: 'ushi',
+  かめ: 'kame',
+  しか: 'shika',
+  つき: 'tsuki',
   はな: 'hana',
+  やま: 'yama',
   そら: 'sora',
+  ゆき: 'yuki',
+  ほし: 'hoshi',
+  みず: 'mizu',
+  かぜ: 'kaze',
+  あめ: 'ame',
+  ゆめ: 'yume',
+  むし: 'mushi',
+  すな: 'suna',
 };
 const REQUIRED_CARDS = 5;
 
@@ -240,12 +255,30 @@ function revealCurrentWord() {
   setIllustrationFor(state.currentWord);
 }
 
-  };
+function setIllustrationFor(word) {
+  if (!illustration) {
+    return;
+  }
 
-  illustration.onload = () => {
-    illustration.classList.add('has-image');
-    illustration.onload = null;
+  const src = getIllustrationFor(word);
+  const altText = word ? `${word}のイラスト` : PLACEHOLDER_IMAGE.alt;
+  const captionText = word ? altText : PLACEHOLDER_IMAGE.caption;
 
+  if (state.currentIllustrationSrc !== src) {
+    illustration.classList.remove('has-image');
+    illustration.onload = () => {
+      illustration.classList.add('has-image');
+      illustration.onload = null;
+    };
+
+    illustration.src = src;
+    state.currentIllustrationSrc = src;
+  }
+
+  illustration.alt = altText;
+  if (caption) {
+    caption.textContent = captionText;
+  }
 }
 
 function setResultText(message, isCorrect) {


### PR DESCRIPTION
## Summary
- map every quiz word to a dedicated SVG illustration file
- add a helper to load illustrations while updating accessible metadata
- create SVG assets for the remaining vocabulary items

## Testing
- node <<'EOF'
const fs = require('fs');
const words = ['ねこ','いぬ','くま','さる','かに','うし','かめ','しか','つき','はな','やま','そら','ゆき','ほし','みず','かぜ','あめ','ゆめ','むし','すな'];
const map = {
  ねこ: 'neko',
  いぬ: 'inu',
  くま: 'kuma',
  さる: 'saru',
  かに: 'kani',
  うし: 'ushi',
  かめ: 'kame',
  しか: 'shika',
  つき: 'tsuki',
  はな: 'hana',
  やま: 'yama',
  そら: 'sora',
  ゆき: 'yuki',
  ほし: 'hoshi',
  みず: 'mizu',
  かぜ: 'kaze',
  あめ: 'ame',
  ゆめ: 'yume',
  むし: 'mushi',
  すな: 'suna',
};
words.forEach((word) => {
  const file = `assets/${map[word] || word}.svg`;
  if (!fs.existsSync(file)) {
    throw new Error(`Missing ${file}`);
  }
});
EOF
- playwright visual confirmation of each word/image pairing

------
https://chatgpt.com/codex/tasks/task_e_68da17b7d278833080098b20264d1bca