### PR TITLE
Improve speech detection compatibility

### DIFF
--- a/main.js
+++ b/main.js
@@ -81,7 +81,8 @@ function detectSpeechSupport() {
 
   return (
     'speechSynthesis' in window &&
-    typeof window.speechSynthesis?.speak === 'function' &&
+    window.speechSynthesis &&
+    typeof window.speechSynthesis.speak === 'function' &&
     typeof window.SpeechSynthesisUtterance === 'function'
   );
 }
@@ -149,7 +150,9 @@ function loadNewProblem() {
 
   const choices = buildChoiceSet(state.currentWord, WORDS);
   cardButtons.forEach((button, index) => {
-    const word = choices[index] ?? '';
+    const choice = choices[index];
+    const word =
+      typeof choice !== 'undefined' && choice !== null ? choice : '';
     button.textContent = word;
     button.dataset.word = word;
     button.classList.remove('selected', 'correct', 'incorrect');


### PR DESCRIPTION
## Summary
- replace the optional chaining check in `detectSpeechSupport` with conventional property checks for broader browser support
- avoid nullish coalescing in the choice card population logic so undefined or null entries fall back safely

## Testing
- not run (manual browser verification required)


------
https://chatgpt.com/codex/tasks/task_e_68da17a3f9648330855f005fff16c79f