### PR TITLE
Add fallback handling for missing illustrations

### DIFF
--- a/main.js
+++ b/main.js
@@ -271,6 +271,19 @@ function setIllustrationFor(word) {
       illustration.onload = null;
     };
 
+    illustration.onerror = () => {
+      console.warn(`イラストの読み込みに失敗しました: ${word || '(placeholder)'}`);
+      illustration.onerror = null;
+      illustration.onload = null;
+      illustration.src = PLACEHOLDER_IMAGE.src;
+      state.currentIllustrationSrc = PLACEHOLDER_IMAGE.src;
+      illustration.classList.add('has-image');
+      illustration.alt = PLACEHOLDER_IMAGE.alt;
+      if (caption) {
+        caption.textContent = PLACEHOLDER_IMAGE.caption;
+      }
+    };
+
     illustration.src = src;
     state.currentIllustrationSrc = src;
   }


### PR DESCRIPTION
## Summary
- add an onerror handler for the illustration element to fall back to the placeholder image and log failures
- reset the caption and alt text to the placeholder copy when the fallback triggers
- confirm every word in WORDS has a corresponding SVG asset

## Testing
- node <<'NODE' ...

------
https://chatgpt.com/codex/tasks/task_e_68da1e561a4c83308592ed6672452028