### PR TITLE
Add illustration preview mode

### DIFF
--- a/main.js
+++ b/main.js
@@ -162,6 +162,7 @@ function loadNewProblem() {
 
   state.selectedWord = null;
   resetPrompt();
+  showIllustrationPreview();
 
   const choices = buildChoiceSet(state.currentWord, WORDS);
   cardButtons.forEach((button, index) => {
@@ -255,10 +256,21 @@ function revealCurrentWord() {
   }
 
   wordDisplay.textContent = state.currentWord;
-  setIllustrationFor(state.currentWord);
+  setIllustrationFor(state.currentWord, { showCaption: true });
 }
 
-function setIllustrationFor(word) {
+function showIllustrationPreview() {
+  if (!state.currentWord) {
+    setIllustrationFor(null, { showCaption: true });
+    return;
+  }
+
+  setIllustrationFor(state.currentWord, { showCaption: false });
+}
+
+function setIllustrationFor(word, options = {}) {
+  const { showCaption = true } = options;
+
   if (!illustration) {
     return;
   }
@@ -284,6 +296,7 @@ function setIllustrationFor(word) {
       illustration.alt = PLACEHOLDER_IMAGE.alt;
       if (caption) {
         caption.textContent = PLACEHOLDER_IMAGE.caption;
+        caption.hidden = false;
       }
     };
 
@@ -293,7 +306,13 @@ function setIllustrationFor(word) {
 
   illustration.alt = altText;
   if (caption) {
-    caption.textContent = captionText;
+    if (showCaption) {
+      caption.textContent = captionText;
+      caption.hidden = false;
+    } else {
+      caption.textContent = '';
+      caption.hidden = true;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- load the new problem illustration immediately in a preview state without revealing the caption
- extend the illustration rendering helper with a caption toggle while keeping the existing fallback behaviour

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68da61dc56a8833093c661518c5429f7