### PR TITLE
Create kawaii illustrations for vocabulary cards

### DIFF
--- a/assets/ame.svg
+++ b/assets/ame.svg
@@ -1,10 +1,27 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
-  <rect width="320" height="240" fill="#577590" rx="24" />
-  <g fill="#ADE8F4">
-    <ellipse cx="90" cy="120" rx="14" ry="20" />
-    <ellipse cx="140" cy="160" rx="12" ry="18" />
-    <ellipse cx="200" cy="110" rx="10" ry="16" />
-    <ellipse cx="240" cy="150" rx="13" ry="19" />
+  <rect width="320" height="240" fill="#577590" rx="28" />
+  <g transform="translate(160 88)">
+    <ellipse cx="0" cy="0" rx="120" ry="54" fill="#CDEDF6" opacity="0.85" />
+    <ellipse cx="-70" cy="8" rx="60" ry="36" fill="#D8F3FE" />
+    <ellipse cx="70" cy="8" rx="60" ry="36" fill="#D8F3FE" />
   </g>
-  <text x="50%" y="82%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="52" fill="#fff">あめ</text>
+  <g fill="#ADE8F4" opacity="0.9">
+    <path d="M70 150c10-42 46-44 60-10 14-34 50-32 60 10" stroke="#fff" stroke-width="0" />
+  </g>
+  <g stroke="#CAF0F8" stroke-width="6" stroke-linecap="round">
+    <path d="M84 146v44" />
+    <path d="M116 158v46" />
+    <path d="M148 146v40" />
+    <path d="M188 154v44" />
+    <path d="M220 140v48" />
+    <path d="M252 158v36" />
+  </g>
+  <g fill="#ADE8F4" opacity="0.8">
+    <ellipse cx="84" cy="196" rx="8" ry="12" />
+    <ellipse cx="148" cy="192" rx="10" ry="14" />
+    <ellipse cx="188" cy="198" rx="9" ry="13" />
+    <ellipse cx="220" cy="194" rx="10" ry="14" />
+  </g>
+  <circle cx="56" cy="66" r="18" fill="#F1FAEE" opacity="0.55" />
+  <circle cx="78" cy="56" r="12" fill="#F1FAEE" opacity="0.35" />
 </svg>

--- a/assets/hana.svg
+++ b/assets/hana.svg
@@ -1,4 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
-  <rect width="320" height="240" fill="#D772B2" rx="24" />
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="64" fill="#fff">はな</text>
+  <rect width="320" height="240" fill="#D772B2" rx="28" />
+  <g transform="translate(160 128)">
+    <circle cx="0" cy="0" r="30" fill="#FFE066" />
+    <g fill="#F4ACB7" opacity="0.95">
+      <path d="M0-28c32-42 90-30 90 10 0 34-40 46-90 18-50 28-90 16-90-18 0-40 58-52 90-10z" />
+    </g>
+    <g fill="#FFCAD4" opacity="0.9">
+      <circle cx="-54" cy="-24" r="36" />
+      <circle cx="54" cy="-24" r="36" />
+      <circle cx="-62" cy="30" r="32" />
+      <circle cx="62" cy="30" r="32" />
+      <circle cx="0" cy="54" r="38" />
+    </g>
+    <circle cx="0" cy="0" r="26" fill="#FFD166" />
+  </g>
+  <path d="M152 168c0 28-12 54-24 68h64c-12-14-24-40-24-68z" fill="#90BE6D" />
+  <path d="M160 176c-26 26-74 42-110 40 36 18 86 12 110-10 24 22 74 28 110 10-36 2-84-14-110-40z" fill="#7FB069" opacity="0.8" />
+  <circle cx="60" cy="60" r="16" fill="#FEECEB" opacity="0.6" />
+  <circle cx="80" cy="48" r="10" fill="#FEECEB" opacity="0.4" />
 </svg>

--- a/assets/hoshi.svg
+++ b/assets/hoshi.svg
@@ -1,5 +1,19 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
-  <rect width="320" height="240" fill="#3D348B" rx="24" />
-  <polygon points="160,70 175,118 226,118 185,148 199,196 160,168 121,196 135,148 94,118 145,118" fill="#FEE440" />
-  <text x="50%" y="85%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="48" fill="#fff">ほし</text>
+  <rect width="320" height="240" fill="#3D348B" rx="28" />
+  <g transform="translate(160 130)">
+    <polygon points="0,-70 20,-16 78,-16 32,18 48,72 0,42 -48,72 -32,18 -78,-16 -20,-16" fill="#FEE440" />
+    <polygon points="0,-36 12,-10 42,-10 18,10 28,38 0,22 -28,38 -18,10 -42,-10 -12,-10" fill="#FADF63" />
+  </g>
+  <g fill="#FEE440" opacity="0.6">
+    <circle cx="70" cy="60" r="12" />
+    <circle cx="240" cy="50" r="8" />
+    <circle cx="270" cy="110" r="10" />
+    <circle cx="90" cy="190" r="6" />
+    <circle cx="220" cy="190" r="7" />
+  </g>
+  <g fill="#FFF3B0" opacity="0.75">
+    <circle cx="50" cy="120" r="6" />
+    <circle cx="112" cy="58" r="8" />
+    <circle cx="260" cy="150" r="6" />
+  </g>
 </svg>

--- a/assets/inu.svg
+++ b/assets/inu.svg
@@ -1,4 +1,24 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
-  <rect width="320" height="240" fill="#C97A40" rx="24" />
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="64" fill="#fff">いぬ</text>
+  <rect width="320" height="240" fill="#C97A40" rx="28" />
+  <g transform="translate(160 144)">
+    <path d="M-92-32c0-44 32-86 92-86s92 42 92 86v62c0 42-40 70-92 70s-92-28-92-70v-62z" fill="#FFE5D0" />
+    <path d="M-94-90c-24-6-42 36-10 64" fill="#FFE5D0" />
+    <path d="M94-90c24-6 42 36 10 64" fill="#FFE5D0" />
+    <ellipse cx="-54" cy="-10" rx="26" ry="32" fill="#8C5A2B" />
+    <ellipse cx="54" cy="-10" rx="26" ry="32" fill="#8C5A2B" />
+    <g fill="#3F2F1E">
+      <circle cx="-40" cy="-12" r="8" />
+      <circle cx="40" cy="-12" r="8" />
+    </g>
+    <path d="M-16 12l16 12 16-12" fill="none" stroke="#3F2F1E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+    <path d="M-44 32c16 18 52 18 68 0" fill="none" stroke="#3F2F1E" stroke-width="6" stroke-linecap="round" />
+    <g fill="#F4C095">
+      <ellipse cx="-22" cy="16" rx="18" ry="22" />
+      <ellipse cx="22" cy="16" rx="18" ry="22" />
+    </g>
+    <ellipse cx="0" cy="24" rx="18" ry="14" fill="#3F2F1E" />
+    <circle cx="0" cy="30" r="6" fill="#FFE5D0" />
+  </g>
+  <circle cx="78" cy="62" r="16" fill="#FFEAD7" opacity="0.6" />
+  <circle cx="94" cy="50" r="10" fill="#FFEAD7" opacity="0.4" />
 </svg>

--- a/assets/kame.svg
+++ b/assets/kame.svg
@@ -1,4 +1,28 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
-  <rect width="320" height="240" fill="#457B9D" rx="24" />
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="64" fill="#fff">かめ</text>
+  <rect width="320" height="240" fill="#457B9D" rx="28" />
+  <g transform="translate(160 140)">
+    <ellipse cx="0" cy="0" rx="96" ry="68" fill="#2A9D8F" />
+    <path d="M0-52c-36 0-72 24-72 56s36 56 72 56 72-24 72-56-36-56-72-56z" fill="#219080" />
+    <g fill="none" stroke="#1B7B6B" stroke-width="8" stroke-linecap="round">
+      <path d="M-60-20h120" />
+      <path d="M-60 12h120" />
+      <path d="M0-52v112" />
+      <path d="M-36-36v80" />
+      <path d="M36-36v80" />
+    </g>
+    <ellipse cx="-110" cy="-6" rx="28" ry="20" fill="#2A9D8F" />
+    <ellipse cx="110" cy="-6" rx="28" ry="20" fill="#2A9D8F" />
+    <ellipse cx="-64" cy="56" rx="18" ry="30" fill="#2A9D8F" />
+    <ellipse cx="64" cy="56" rx="18" ry="30" fill="#2A9D8F" />
+    <g transform="translate(-120 -20)">
+      <circle cx="0" cy="0" r="22" fill="#2A9D8F" />
+      <ellipse cx="-6" cy="-4" rx="6" ry="8" fill="#fff" opacity="0.9" />
+      <ellipse cx="10" cy="-4" rx="6" ry="8" fill="#fff" opacity="0.9" />
+      <circle cx="-6" cy="-4" r="3.5" fill="#1B4F4A" />
+      <circle cx="10" cy="-4" r="3.5" fill="#1B4F4A" />
+      <path d="M-4 6c4 6 12 6 16 0" fill="none" stroke="#1B4F4A" stroke-width="3.5" stroke-linecap="round" />
+    </g>
+  </g>
+  <circle cx="70" cy="60" r="12" fill="#F1FAEE" opacity="0.7" />
+  <circle cx="90" cy="50" r="8" fill="#F1FAEE" opacity="0.5" />
 </svg>

--- a/assets/kani.svg
+++ b/assets/kani.svg
@@ -1,4 +1,29 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
-  <rect width="320" height="240" fill="#F25C54" rx="24" />
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="64" fill="#fff">かに</text>
+  <rect width="320" height="240" fill="#F25C54" rx="28" />
+  <g transform="translate(160 150)">
+    <ellipse cx="0" cy="0" rx="94" ry="54" fill="#FF8A7A" />
+    <path d="M-92-10c-18-16-38-44-20-62 18-18 46 6 56 26" fill="#FF8A7A" />
+    <path d="M92-10c18-16 38-44 20-62-18-18-46 6-56 26" fill="#FF8A7A" />
+    <g fill="#F25C54">
+      <path d="M-110-68c-18-6-30 20-8 40 0-20 10-28 22-30" />
+      <path d="M110-68c18-6 30 20 8 40 0-20-10-28-22-30" />
+    </g>
+    <g fill="#F25C54">
+      <ellipse cx="-74" cy="30" rx="16" ry="28" />
+      <ellipse cx="74" cy="30" rx="16" ry="28" />
+    </g>
+    <g fill="#3B1813">
+      <circle cx="-28" cy="-10" r="8" />
+      <circle cx="28" cy="-10" r="8" />
+    </g>
+    <path d="M-36 20c18 12 54 12 72 0" fill="none" stroke="#3B1813" stroke-width="6" stroke-linecap="round" />
+    <g stroke="#F25C54" stroke-width="8" stroke-linecap="round">
+      <path d="M-94 6l-34-6" />
+      <path d="M-92 22l-32 12" />
+      <path d="M94 6l34-6" />
+      <path d="M92 22l32 12" />
+    </g>
+  </g>
+  <circle cx="70" cy="60" r="16" fill="#FFDAD6" opacity="0.55" />
+  <circle cx="88" cy="48" r="10" fill="#FFDAD6" opacity="0.4" />
 </svg>

--- a/assets/kaze.svg
+++ b/assets/kaze.svg
@@ -1,6 +1,17 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
-  <rect width="320" height="240" fill="#8ECAE6" rx="24" />
-  <path d="M60 120h140c15 0 28-10 28-22s-13-22-28-22" fill="none" stroke="#023047" stroke-width="12" stroke-linecap="round" />
-  <path d="M90 160h110c12 0 22-8 22-18s-10-18-22-18" fill="none" stroke="#023047" stroke-width="12" stroke-linecap="round" opacity="0.8" />
-  <text x="50%" y="80%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="52" fill="#023047">かぜ</text>
+  <rect width="320" height="240" fill="#8ECAE6" rx="28" />
+  <g fill="none" stroke="#023047" stroke-width="12" stroke-linecap="round">
+    <path d="M60 120h140c18 0 34-12 34-28s-16-28-34-28" />
+    <path d="M90 164h130c14 0 26-10 26-24s-12-24-26-24" opacity="0.85" />
+    <path d="M110 92h70c12 0 22-8 22-18s-10-18-22-18" opacity="0.6" />
+  </g>
+  <g fill="#fff" opacity="0.6">
+    <ellipse cx="98" cy="188" rx="20" ry="10" />
+    <ellipse cx="220" cy="60" rx="18" ry="12" />
+    <ellipse cx="60" cy="76" rx="16" ry="10" />
+  </g>
+  <g fill="#219EBC" opacity="0.4">
+    <circle cx="250" cy="160" r="12" />
+    <circle cx="86" cy="48" r="8" />
+  </g>
 </svg>

--- a/assets/kuma.svg
+++ b/assets/kuma.svg
@@ -1,4 +1,22 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
-  <rect width="320" height="240" fill="#F4A261" rx="24" />
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="64" fill="#fff">くま</text>
+  <rect width="320" height="240" fill="#F4A261" rx="28" />
+  <g transform="translate(160 130)">
+    <circle cx="0" cy="0" r="78" fill="#8D5524" />
+    <g fill="#8D5524">
+      <circle cx="-58" cy="-58" r="28" />
+      <circle cx="58" cy="-58" r="28" />
+    </g>
+    <circle cx="0" cy="20" r="44" fill="#D9A066" />
+    <ellipse cx="-28" cy="-10" rx="14" ry="18" fill="#FFF" opacity="0.95" />
+    <ellipse cx="28" cy="-10" rx="14" ry="18" fill="#FFF" opacity="0.95" />
+    <circle cx="-28" cy="-10" r="6" fill="#3C2F2F" />
+    <circle cx="28" cy="-10" r="6" fill="#3C2F2F" />
+    <path d="M0-6c12 0 18 10 18 20s-6 20-18 20-18-10-18-20 6-20 18-20z" fill="#5B3B1F" />
+    <circle cx="0" cy="10" r="10" fill="#FFF" opacity="0.8" />
+    <path d="M-20 28c12 18 48 18 60 0" fill="none" stroke="#5B3B1F" stroke-width="8" stroke-linecap="round" />
+    <circle cx="-46" cy="40" r="12" fill="#8D5524" />
+    <circle cx="46" cy="40" r="12" fill="#8D5524" />
+  </g>
+  <circle cx="260" cy="60" r="14" fill="#FDEAC1" opacity="0.6" />
+  <circle cx="250" cy="48" r="8" fill="#FDEAC1" opacity="0.45" />
 </svg>

--- a/assets/mizu.svg
+++ b/assets/mizu.svg
@@ -1,5 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
-  <rect width="320" height="240" fill="#48CAE4" rx="24" />
-  <path d="M160 60c30 40 60 70 60 100a60 60 0 0 1-120 0c0-30 30-60 60-100z" fill="#023E8A" opacity="0.7" />
-  <text x="50%" y="82%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="52" fill="#fff">みず</text>
+  <rect width="320" height="240" fill="#48CAE4" rx="28" />
+  <path d="M160 60c30 40 72 76 72 112a72 72 0 0 1-144 0c0-36 42-72 72-112z" fill="#0096C7" opacity="0.75" />
+  <path d="M160 76c22 32 52 60 52 92a52 52 0 0 1-104 0c0-32 30-60 52-92z" fill="#ADE8F4" opacity="0.9" />
+  <path d="M112 178c14 14 44 22 80 0" fill="none" stroke="#023E8A" stroke-width="8" stroke-linecap="round" opacity="0.6" />
+  <g fill="#ADE8F4" opacity="0.7">
+    <circle cx="82" cy="70" r="16" />
+    <circle cx="238" cy="68" r="12" />
+    <circle cx="100" cy="50" r="8" />
+  </g>
 </svg>

--- a/assets/mushi.svg
+++ b/assets/mushi.svg
@@ -1,7 +1,26 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
-  <rect width="320" height="240" fill="#2D6A4F" rx="24" />
-  <circle cx="130" cy="120" r="28" fill="#95D5B2" />
-  <circle cx="190" cy="120" r="24" fill="#95D5B2" />
-  <rect x="150" y="80" width="20" height="80" rx="10" fill="#40916C" />
-  <text x="50%" y="85%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="48" fill="#fff">むし</text>
+  <rect width="320" height="240" fill="#2D6A4F" rx="28" />
+  <g transform="translate(160 132)">
+    <ellipse cx="-24" cy="0" rx="42" ry="48" fill="#74C69D" />
+    <ellipse cx="24" cy="0" rx="42" ry="48" fill="#52B788" />
+    <circle cx="-56" cy="-48" r="18" fill="#40916C" />
+    <circle cx="56" cy="-48" r="18" fill="#40916C" />
+    <ellipse cx="-24" cy="-52" rx="22" ry="18" fill="#95D5B2" />
+    <ellipse cx="24" cy="-52" rx="22" ry="18" fill="#95D5B2" />
+    <g fill="#1B4332">
+      <circle cx="-32" cy="-54" r="4" />
+      <circle cx="32" cy="-54" r="4" />
+    </g>
+    <path d="M0-52c0 16 18 28 18 44s-18 30-18 46" fill="none" stroke="#1B4332" stroke-width="6" stroke-linecap="round" />
+    <path d="M0-52c0 16-18 28-18 44s18 30 18 46" fill="none" stroke="#1B4332" stroke-width="6" stroke-linecap="round" />
+    <path d="M-58-66c-18-24-40-24-40-4 0 16 24 24 40 22" fill="none" stroke="#40916C" stroke-width="6" stroke-linecap="round" />
+    <path d="M58-66c18-24 40-24 40-4 0 16-24 24-40 22" fill="none" stroke="#40916C" stroke-width="6" stroke-linecap="round" />
+    <g fill="#1B4332">
+      <circle cx="0" cy="-12" r="6" />
+      <circle cx="0" cy="12" r="6" />
+      <circle cx="0" cy="36" r="6" />
+    </g>
+  </g>
+  <circle cx="62" cy="58" r="16" fill="#D8F3DC" opacity="0.6" />
+  <circle cx="82" cy="48" r="10" fill="#D8F3DC" opacity="0.4" />
 </svg>

--- a/assets/neko.svg
+++ b/assets/neko.svg
@@ -1,4 +1,31 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
-  <rect width="320" height="240" fill="#6C7AE0" rx="24" />
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="64" fill="#fff">ねこ</text>
+  <rect width="320" height="240" fill="#6C7AE0" rx="28" />
+  <g transform="translate(160 140)">
+    <path d="M-90-32c0-48 34-86 90-86s90 38 90 86v70c0 42-42 70-90 70s-90-28-90-70v-70z" fill="#F5F0FF" />
+    <path d="M-96-74l32-44 26 42" fill="#F5F0FF" />
+    <path d="M96-74l-32-44-26 42" fill="#F5F0FF" />
+    <g fill="#E5D7FF">
+      <ellipse cx="-58" cy="-12" rx="26" ry="30" />
+      <ellipse cx="58" cy="-12" rx="26" ry="30" />
+    </g>
+    <g fill="#3C3273">
+      <circle cx="-40" cy="-12" r="8" />
+      <circle cx="40" cy="-12" r="8" />
+    </g>
+    <path d="M-16 8l16 12 16-12" fill="none" stroke="#3C3273" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+    <g stroke="#3C3273" stroke-width="5" stroke-linecap="round">
+      <path d="M-68 12h34" />
+      <path d="M-70 20h38" />
+      <path d="M68 12h-34" />
+      <path d="M70 20h-38" />
+    </g>
+    <circle cx="0" cy="30" r="28" fill="#FFACC5" opacity="0.6" />
+    <path d="M-28 40c18 14 38 14 56 0" fill="none" stroke="#3C3273" stroke-width="6" stroke-linecap="round" />
+    <g fill="#3C3273">
+      <circle cx="-16" cy="22" r="4" />
+      <circle cx="16" cy="22" r="4" />
+    </g>
+  </g>
+  <circle cx="260" cy="52" r="14" fill="#FFFFFF" opacity="0.5" />
+  <circle cx="244" cy="44" r="8" fill="#FFFFFF" opacity="0.35" />
 </svg>

--- a/assets/placeholder.svg
+++ b/assets/placeholder.svg
@@ -1,4 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
-  <rect width="320" height="240" fill="#E0E0E0" rx="24" />
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="72" fill="#555">？</text>
+  <rect width="320" height="240" fill="#E0E0E0" rx="28" />
+  <g transform="translate(160 120)">
+    <path d="M-28-20c0-26 18-44 48-44 24 0 46 16 46 40 0 22-14 34-26 44-8 6-16 12-16 24v6h-20v-8c0-16 10-26 22-36 8-6 16-14 16-24 0-12-10-20-22-20-18 0-26 12-26 26h-22z" fill="#B0B0B0" opacity="0.7" />
+    <circle cx="2" cy="64" r="12" fill="#B0B0B0" opacity="0.7" />
+  </g>
+  <g fill="#fff" opacity="0.6">
+    <circle cx="76" cy="60" r="14" />
+    <circle cx="242" cy="52" r="10" />
+  </g>
 </svg>

--- a/assets/sake.svg
+++ b/assets/sake.svg
@@ -1,4 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
-  <rect width="320" height="240" fill="#F18FB0" rx="24" />
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="64" fill="#fff">さけ</text>
+  <rect width="320" height="240" fill="#F18FB0" rx="28" />
+  <g transform="translate(160 140)">
+    <path d="M-120-14c34-38 92-60 120-60s86 22 120 60c-34 38-92 60-120 60s-86-22-120-60z" fill="#FFD5DD" />
+    <path d="M-80-14c24-26 64-40 80-40s56 14 80 40c-24 26-64 40-80 40s-56-14-80-40z" fill="#FFB3C1" />
+    <path d="M-36-8c12-12 28-18 36-18s24 6 36 18c-12 12-28 18-36 18s-24-6-36-18z" fill="#F46AA3" />
+    <g fill="#253237">
+      <circle cx="-62" cy="-6" r="6" />
+      <circle cx="62" cy="-6" r="6" />
+    </g>
+    <path d="M-90-22l-30-20c-8-6-20 6-12 14l26 26" fill="#FFD5DD" />
+    <path d="M90-22l30-20c8-6 20 6 12 14l-26 26" fill="#FFD5DD" />
+    <path d="M-86 26l-28 20c-8 6 4 20 12 14l30-20" fill="#FFD5DD" />
+    <path d="M86 26l28 20c8 6-4 20-12 14l-30-20" fill="#FFD5DD" />
+  </g>
+  <circle cx="78" cy="60" r="16" fill="#FFE6EE" opacity="0.6" />
+  <circle cx="96" cy="50" r="10" fill="#FFE6EE" opacity="0.4" />
 </svg>

--- a/assets/saru.svg
+++ b/assets/saru.svg
@@ -1,4 +1,24 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
-  <rect width="320" height="240" fill="#E76F51" rx="24" />
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="64" fill="#fff">さる</text>
+  <rect width="320" height="240" fill="#E76F51" rx="28" />
+  <g transform="translate(160 140)">
+    <circle cx="0" cy="0" r="86" fill="#A44A34" />
+    <circle cx="0" cy="12" r="64" fill="#F6D6BF" />
+    <g fill="#A44A34">
+      <circle cx="-62" cy="-44" r="30" />
+      <circle cx="62" cy="-44" r="30" />
+    </g>
+    <g fill="#FFF" opacity="0.9">
+      <ellipse cx="-24" cy="-10" rx="14" ry="18" />
+      <ellipse cx="24" cy="-10" rx="14" ry="18" />
+    </g>
+    <circle cx="-24" cy="-10" r="7" fill="#40251C" />
+    <circle cx="24" cy="-10" r="7" fill="#40251C" />
+    <ellipse cx="0" cy="20" rx="28" ry="24" fill="#F0B7A9" />
+    <path d="M-20 24c12 10 28 10 40 0" fill="none" stroke="#40251C" stroke-width="6" stroke-linecap="round" />
+    <circle cx="-58" cy="30" r="18" fill="#A44A34" />
+    <circle cx="58" cy="30" r="18" fill="#A44A34" />
+    <path d="M-64 56c24 24 104 24 128 0" fill="none" stroke="#A44A34" stroke-width="10" stroke-linecap="round" />
+  </g>
+  <circle cx="82" cy="64" r="14" fill="#FDEAD3" opacity="0.6" />
+  <circle cx="96" cy="52" r="8" fill="#FDEAD3" opacity="0.4" />
 </svg>

--- a/assets/shika.svg
+++ b/assets/shika.svg
@@ -1,4 +1,32 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
-  <rect width="320" height="240" fill="#F6BD60" rx="24" />
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="64" fill="#4D331F">しか</text>
+  <rect width="320" height="240" fill="#F6BD60" rx="28" />
+  <g transform="translate(160 146)">
+    <path d="M-100-24c0-52 42-96 100-96s100 44 100 96v58c0 44-48 70-100 70s-100-26-100-70v-58z" fill="#F4D7A3" />
+    <path d="M-92-70c-16-26 12-58 32-38l40 40" fill="#F4D7A3" />
+    <path d="M92-70c16-26-12-58-32-38l-40 40" fill="#F4D7A3" />
+    <g fill="#B07D44">
+      <ellipse cx="-62" cy="-4" rx="26" ry="32" />
+      <ellipse cx="62" cy="-4" rx="26" ry="32" />
+    </g>
+    <g fill="#3F301D">
+      <circle cx="-44" cy="-6" r="7" />
+      <circle cx="44" cy="-6" r="7" />
+    </g>
+    <path d="M-24 18l24 18 24-18" fill="none" stroke="#3F301D" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+    <g fill="#F8E3C5">
+      <ellipse cx="-24" cy="26" rx="20" ry="24" />
+      <ellipse cx="24" cy="26" rx="20" ry="24" />
+    </g>
+    <path d="M-38 42c16 12 44 12 60 0" fill="none" stroke="#3F301D" stroke-width="6" stroke-linecap="round" />
+    <ellipse cx="0" cy="34" rx="16" ry="12" fill="#3F301D" />
+    <circle cx="0" cy="36" r="5" fill="#F8E3C5" />
+    <g fill="none" stroke="#B07D44" stroke-width="8" stroke-linecap="round">
+      <path d="M-52-90l-32-24" />
+      <path d="M-46-74l-38-6" />
+      <path d="M52-90l32-24" />
+      <path d="M46-74l38-6" />
+    </g>
+  </g>
+  <circle cx="62" cy="60" r="16" fill="#FFF2DE" opacity="0.6" />
+  <circle cx="82" cy="48" r="10" fill="#FFF2DE" opacity="0.4" />
 </svg>

--- a/assets/sora.svg
+++ b/assets/sora.svg
@@ -1,4 +1,21 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
-  <rect width="320" height="240" fill="#7DC3FF" rx="24" />
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="64" fill="#fff">そら</text>
+  <rect width="320" height="240" fill="#7DC3FF" rx="28" />
+  <path d="M0 170c40-30 100-50 160-50s120 20 160 50v70H0z" fill="#4DA3EC" opacity="0.35" />
+  <g fill="#fff" opacity="0.85">
+    <ellipse cx="84" cy="90" rx="48" ry="22" />
+    <ellipse cx="128" cy="92" rx="44" ry="20" />
+    <ellipse cx="208" cy="78" rx="42" ry="20" />
+    <ellipse cx="244" cy="82" rx="36" ry="18" />
+    <ellipse cx="160" cy="70" rx="52" ry="24" />
+  </g>
+  <g fill="#fff" opacity="0.7">
+    <ellipse cx="66" cy="138" rx="34" ry="16" />
+    <ellipse cx="118" cy="146" rx="38" ry="18" />
+    <ellipse cx="202" cy="136" rx="34" ry="16" />
+    <ellipse cx="248" cy="144" rx="30" ry="14" />
+  </g>
+  <g fill="#FFD166" opacity="0.9">
+    <circle cx="248" cy="56" r="18" />
+    <circle cx="262" cy="50" r="10" opacity="0.6" />
+  </g>
 </svg>

--- a/assets/suna.svg
+++ b/assets/suna.svg
@@ -1,5 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
-  <rect width="320" height="240" fill="#FFB703" rx="24" />
-  <path d="M40 180c40-40 80-60 120-60s80 20 120 60v20H40z" fill="#E9C46A" />
-  <text x="50%" y="70%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="56" fill="#8D5524">すな</text>
+  <rect width="320" height="240" fill="#FFB703" rx="28" />
+  <path d="M40 180c40-40 80-60 120-60s80 20 120 60v40H40z" fill="#F4A261" />
+  <path d="M60 188c28-30 64-44 100-44s72 14 100 44v32H60z" fill="#E9C46A" />
+  <g fill="#fff" opacity="0.45">
+    <circle cx="92" cy="112" r="6" />
+    <circle cx="124" cy="124" r="5" />
+    <circle cx="186" cy="118" r="6" />
+    <circle cx="220" cy="132" r="5" />
+    <circle cx="150" cy="136" r="5" />
+  </g>
+  <g fill="none" stroke="#C77D24" stroke-width="4" stroke-linecap="round" opacity="0.6">
+    <path d="M92 188c12-8 32-14 48-14s36 6 48 14" />
+    <path d="M110 204c8-6 24-10 38-10s30 4 38 10" />
+  </g>
+  <circle cx="246" cy="70" r="18" fill="#FFE8A1" opacity="0.7" />
+  <circle cx="260" cy="60" r="10" fill="#FFE8A1" opacity="0.4" />
 </svg>

--- a/assets/tsuki.svg
+++ b/assets/tsuki.svg
@@ -1,5 +1,14 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
-  <rect width="320" height="240" fill="#2D5D8F" rx="24" />
-  <circle cx="220" cy="100" r="60" fill="#FEE440" opacity="0.9" />
-  <text x="50%" y="70%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="56" fill="#fff">つき</text>
+  <rect width="320" height="240" fill="#2D5D8F" rx="28" />
+  <circle cx="216" cy="96" r="70" fill="#FEE440" opacity="0.9" />
+  <circle cx="240" cy="86" r="70" fill="#2D5D8F" opacity="0.4" />
+  <g fill="#fff" opacity="0.8">
+    <circle cx="80" cy="140" r="6" />
+    <circle cx="110" cy="110" r="4" />
+    <circle cx="60" cy="100" r="3" />
+    <circle cx="140" cy="70" r="5" />
+    <circle cx="90" cy="60" r="4" />
+    <circle cx="180" cy="150" r="4" />
+  </g>
+  <path d="M40 200c26-28 70-48 120-48s94 20 120 48v40H40z" fill="#1C3D5A" opacity="0.6" />
 </svg>

--- a/assets/umi.svg
+++ b/assets/umi.svg
@@ -1,4 +1,14 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
-  <rect width="320" height="240" fill="#4FB0C6" rx="24" />
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="64" fill="#fff">うみ</text>
+  <rect width="320" height="240" fill="#4FB0C6" rx="28" />
+  <path d="M0 150c20-14 60-34 120-34s100 20 120 34c20 14 60 34 80 34v90H-80v-90c20 0 60-20 80-34z" fill="#2C699A" opacity="0.55" />
+  <path d="M-40 162c24-16 64-28 120-28s96 12 120 28 64 28 120 28v80H-160v-80c56 0 96-12 120-28z" fill="#1D4F8A" opacity="0.4" />
+  <g fill="none" stroke="#D8F3FF" stroke-width="6" stroke-linecap="round" opacity="0.7">
+    <path d="M40 150c16 8 36 12 56 12s40-4 56-12" />
+    <path d="M80 176c18 10 46 10 64 0" />
+    <path d="M120 204c14 8 32 8 46 0" />
+  </g>
+  <g fill="#F1FAEE" opacity="0.7">
+    <circle cx="220" cy="72" r="22" />
+    <circle cx="236" cy="62" r="12" opacity="0.6" />
+  </g>
 </svg>

--- a/assets/ushi.svg
+++ b/assets/ushi.svg
@@ -1,4 +1,31 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
-  <rect width="320" height="240" fill="#2A9D8F" rx="24" />
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="64" fill="#fff">うし</text>
+  <rect width="320" height="240" fill="#2A9D8F" rx="28" />
+  <g transform="translate(160 150)">
+    <path d="M-110-40c30-30 70-46 110-46s80 16 110 46v70c0 36-32 66-110 66s-110-30-110-66v-70z" fill="#F7F2EE" />
+    <path d="M-90-30c16-18 42-34 90-34s74 16 90 34v54c0 24-26 44-90 44s-90-20-90-44v-54z" fill="#F0E0DA" />
+    <g fill="#E09C5A">
+      <path d="M-84-80c-16 0-28 18-18 32l20 30 18-14-20-48z" />
+      <path d="M84-80c16 0 28 18 18 32l-20 30-18-14 20-48z" />
+    </g>
+    <ellipse cx="-44" cy="-22" rx="18" ry="22" fill="#3F3D56" />
+    <ellipse cx="44" cy="-22" rx="18" ry="22" fill="#3F3D56" />
+    <ellipse cx="0" cy="36" rx="72" ry="50" fill="#FCD4DC" />
+    <g fill="#3F3D56">
+      <circle cx="-26" cy="18" r="6" />
+      <circle cx="26" cy="18" r="6" />
+      <path d="M-22 42c12 10 34 10 46 0" fill="none" stroke="#3F3D56" stroke-width="6" stroke-linecap="round" />
+    </g>
+    <g fill="#3F3D56">
+      <ellipse cx="-64" cy="0" rx="12" ry="20" />
+      <ellipse cx="64" cy="0" rx="12" ry="20" />
+    </g>
+    <path d="M-34-74c-10-30 12-54 34-54s44 24 34 54c-6 18-22 22-34 22s-28-4-34-22z" fill="#F7F2EE" />
+    <g transform="translate(0 -66)" fill="#3F3D56">
+      <circle cx="-16" cy="0" r="6" />
+      <circle cx="16" cy="0" r="6" />
+      <path d="M-10 14c6 4 14 4 20 0" fill="none" stroke="#3F3D56" stroke-width="4" stroke-linecap="round" />
+    </g>
+  </g>
+  <circle cx="54" cy="54" r="16" fill="#FDF6E4" opacity="0.65" />
+  <circle cx="72" cy="46" r="10" fill="#FDF6E4" opacity="0.45" />
 </svg>

--- a/assets/yama.svg
+++ b/assets/yama.svg
@@ -1,6 +1,17 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
-  <rect width="320" height="240" fill="#84A59D" rx="24" />
+  <rect width="320" height="240" fill="#84A59D" rx="28" />
   <polygon points="40,200 120,80 200,200" fill="#52796F" />
   <polygon points="120,200 200,90 280,200" fill="#354F52" opacity="0.85" />
-  <text x="50%" y="75%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="56" fill="#fff">やま</text>
+  <polygon points="100,200 160,110 220,200" fill="#6B9080" opacity="0.7" />
+  <path d="M120 128l16 16 20-36 18 28 18-26" fill="none" stroke="#F4F1DE" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M0 200c40-24 100-40 160-40s120 16 160 40v40H0z" fill="#52796F" opacity="0.5" />
+  <g fill="#F6BD60" opacity="0.85">
+    <circle cx="74" cy="58" r="18" />
+    <circle cx="88" cy="50" r="10" opacity="0.6" />
+  </g>
+  <g fill="#F4F1DE" opacity="0.7">
+    <circle cx="230" cy="70" r="6" />
+    <circle cx="250" cy="60" r="5" />
+    <circle cx="210" cy="56" r="4" />
+  </g>
 </svg>

--- a/assets/yuki.svg
+++ b/assets/yuki.svg
@@ -1,4 +1,31 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
-  <rect width="320" height="240" fill="#B5E48C" rx="24" />
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="64" fill="#1B4332">ゆき</text>
+  <rect width="320" height="240" fill="#B5E48C" rx="28" />
+  <path d="M0 192c28-22 76-38 160-38s132 16 160 38v48H0z" fill="#99D98C" opacity="0.6" />
+  <g transform="translate(160 150)">
+    <circle cx="0" cy="60" r="50" fill="#FFFFFF" opacity="0.95" />
+    <circle cx="0" cy="0" r="38" fill="#FFFFFF" opacity="0.95" />
+    <circle cx="0" cy="-48" r="26" fill="#FFFFFF" opacity="0.95" />
+    <g fill="#1B4332">
+      <circle cx="-10" cy="-56" r="4" />
+      <circle cx="10" cy="-56" r="4" />
+      <circle cx="0" cy="-40" r="4" />
+      <circle cx="0" cy="-26" r="4" />
+      <circle cx="0" cy="-12" r="4" />
+      <circle cx="0" cy="4" r="4" />
+      <circle cx="0" cy="18" r="4" />
+      <circle cx="0" cy="34" r="4" />
+    </g>
+    <path d="M-32-10l-36-20" fill="none" stroke="#E36414" stroke-width="8" stroke-linecap="round" />
+    <path d="M32-10l36-20" fill="none" stroke="#E36414" stroke-width="8" stroke-linecap="round" />
+    <path d="M-12-58c8-4 16-4 24 0" fill="none" stroke="#1B4332" stroke-width="4" stroke-linecap="round" />
+    <path d="M0-48l18 8-18 8z" fill="#FF6B6B" />
+  </g>
+  <g fill="#FFFFFF" opacity="0.7">
+    <circle cx="60" cy="60" r="8" />
+    <circle cx="90" cy="48" r="6" />
+    <circle cx="240" cy="70" r="8" />
+    <circle cx="210" cy="50" r="5" />
+    <circle cx="120" cy="80" r="6" />
+    <circle cx="260" cy="90" r="6" />
+  </g>
 </svg>

--- a/assets/yume.svg
+++ b/assets/yume.svg
@@ -1,7 +1,23 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
-  <rect width="320" height="240" fill="#9D4EDD" rx="24" />
-  <circle cx="90" cy="90" r="26" fill="#FDE2FF" opacity="0.8" />
-  <circle cx="130" cy="60" r="18" fill="#FDE2FF" opacity="0.7" />
-  <circle cx="200" cy="90" r="22" fill="#FDE2FF" opacity="0.75" />
-  <text x="50%" y="80%" dominant-baseline="middle" text-anchor="middle" font-family="Noto Sans JP, sans-serif" font-size="52" fill="#fff">ゆめ</text>
+  <rect width="320" height="240" fill="#9D4EDD" rx="28" />
+  <g fill="#FDE2FF" opacity="0.8">
+    <circle cx="90" cy="90" r="26" />
+    <circle cx="130" cy="60" r="18" />
+    <circle cx="200" cy="90" r="22" />
+    <circle cx="150" cy="120" r="34" opacity="0.7" />
+    <circle cx="220" cy="130" r="28" opacity="0.6" />
+    <circle cx="120" cy="150" r="24" opacity="0.6" />
+  </g>
+  <g fill="#FFF4FE" opacity="0.85">
+    <path d="M80 184c18-18 44-28 80-28s62 10 80 28v28H80z" />
+  </g>
+  <g fill="#FEE440" opacity="0.85">
+    <circle cx="240" cy="62" r="12" />
+    <circle cx="252" cy="54" r="8" opacity="0.6" />
+  </g>
+  <g fill="#F8F0FF" opacity="0.7">
+    <circle cx="64" cy="70" r="6" />
+    <circle cx="96" cy="52" r="5" />
+    <circle cx="180" cy="54" r="4" />
+  </g>
 </svg>


### PR DESCRIPTION
## Summary
- replace text-based placeholders for animal vocabulary cards with new kawaii-style vector illustrations
- redesign weather, nature, and object cards to remove text labels while keeping readable imagery and the original viewBox
- refresh the placeholder card to use iconography instead of text so every SVG is image-only

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68ddc6890df483308cb47cf518441f39