### PR TITLE
Redraw cat, dog, and cow SVG cards

### DIFF
--- a/assets/inu.svg
+++ b/assets/inu.svg
@@ -1,23 +1,30 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
   <rect width="320" height="240" fill="#C97A40" rx="28" />
-  <g transform="translate(160 144)">
-    <path d="M-92-32c0-44 32-86 92-86s92 42 92 86v62c0 42-40 70-92 70s-92-28-92-70v-62z" fill="#FFE5D0" />
-    <path d="M-94-90c-24-6-42 36-10 64" fill="#FFE5D0" />
-    <path d="M94-90c24-6 42 36 10 64" fill="#FFE5D0" />
-    <ellipse cx="-54" cy="-10" rx="26" ry="32" fill="#8C5A2B" />
-    <ellipse cx="54" cy="-10" rx="26" ry="32" fill="#8C5A2B" />
+  <g transform="translate(160 132)">
+    <path d="M92 70c22 2 32 22 20 40s-34 26-56 20" fill="none" stroke="#FFE5D0" stroke-width="18" stroke-linecap="round" />
+    <ellipse cx="0" cy="72" rx="88" ry="58" fill="#FFE5D0" />
+    <ellipse cx="0" cy="74" rx="50" ry="40" fill="#F4C095" />
+    <path d="M-92 34c-22 2-32 22-20 40s34 26 56 20" fill="none" stroke="#FFE5D0" stroke-width="18" stroke-linecap="round" />
+    <g fill="#FFE5D0">
+      <circle cx="0" cy="-8" r="58" />
+      <path d="M-32-24c-26-26-60-14-54 20 4 22 16 36 26 44l30-24z" />
+      <path d="M32-24c26-26 60-14 54 20-4 22-16 36-26 44l-30-24z" />
+    </g>
+    <path d="M-46-18c-18-16-46-6-40 18 4 18 14 28 26 34l24-26z" fill="#8C5A2B" />
+    <path d="M46-18c18-16 46-6 40 18-4 18-14 28-26 34l-24-26z" fill="#8C5A2B" />
+    <ellipse cx="0" cy="24" rx="40" ry="34" fill="#F4C095" />
+    <ellipse cx="0" cy="34" rx="24" ry="18" fill="#3F2F1E" />
+    <path d="M0 42c8 0 14 6 14 14s-8 14-14 14-14-6-14-14 6-14 14-14z" fill="#FFE5D0" />
     <g fill="#3F2F1E">
-      <circle cx="-40" cy="-12" r="8" />
-      <circle cx="40" cy="-12" r="8" />
+      <circle cx="-20" cy="-8" r="10" />
+      <circle cx="20" cy="-8" r="10" />
     </g>
-    <path d="M-16 12l16 12 16-12" fill="none" stroke="#3F2F1E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
-    <path d="M-44 32c16 18 52 18 68 0" fill="none" stroke="#3F2F1E" stroke-width="6" stroke-linecap="round" />
-    <g fill="#F4C095">
-      <ellipse cx="-22" cy="16" rx="18" ry="22" />
-      <ellipse cx="22" cy="16" rx="18" ry="22" />
+    <path d="M-18 10c8 8 28 8 36 0" fill="none" stroke="#3F2F1E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
+    <g fill="#8C5A2B">
+      <circle cx="-34" cy="18" r="12" />
+      <circle cx="34" cy="18" r="12" />
     </g>
-    <ellipse cx="0" cy="24" rx="18" ry="14" fill="#3F2F1E" />
-    <circle cx="0" cy="30" r="6" fill="#FFE5D0" />
+    <path d="M-72 56c12 18 30 26 72 26s60-8 72-26" fill="none" stroke="#3F2F1E" stroke-width="6" stroke-linecap="round" />
   </g>
   <circle cx="78" cy="62" r="16" fill="#FFEAD7" opacity="0.6" />
   <circle cx="94" cy="50" r="10" fill="#FFEAD7" opacity="0.4" />

--- a/assets/neko.svg
+++ b/assets/neko.svg
@@ -1,30 +1,36 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
   <rect width="320" height="240" fill="#6C7AE0" rx="28" />
-  <g transform="translate(160 140)">
-    <path d="M-90-32c0-48 34-86 90-86s90 38 90 86v70c0 42-42 70-90 70s-90-28-90-70v-70z" fill="#F5F0FF" />
-    <path d="M-96-74l32-44 26 42" fill="#F5F0FF" />
-    <path d="M96-74l-32-44-26 42" fill="#F5F0FF" />
-    <g fill="#E5D7FF">
-      <ellipse cx="-58" cy="-12" rx="26" ry="30" />
-      <ellipse cx="58" cy="-12" rx="26" ry="30" />
+  <g transform="translate(160 128)">
+    <ellipse cx="0" cy="68" rx="78" ry="52" fill="#F5F0FF" />
+    <path d="M68 72c30 4 44 28 32 52-10 20-34 30-58 18" fill="none" stroke="#F5F0FF" stroke-width="18" stroke-linecap="round" />
+    <g fill="#F5F0FF">
+      <circle cx="0" cy="-6" r="62" />
+      <path d="M-48-32l-44-30 6 56z" />
+      <path d="M48-32l44-30-6 56z" />
     </g>
+    <g fill="#FFACC5">
+      <path d="M-46-34l-22-16 4 28z" />
+      <path d="M46-34l22-16-4 28z" />
+      <ellipse cx="0" cy="30" rx="28" ry="24" />
+    </g>
+    <path d="M-12 22h24" stroke="#3C3273" stroke-width="6" stroke-linecap="round" />
+    <path d="M-20 12c6-4 14-4 20 0" fill="none" stroke="#3C3273" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
     <g fill="#3C3273">
-      <circle cx="-40" cy="-12" r="8" />
-      <circle cx="40" cy="-12" r="8" />
+      <circle cx="-22" cy="-12" r="10" />
+      <circle cx="22" cy="-12" r="10" />
     </g>
-    <path d="M-16 8l16 12 16-12" fill="none" stroke="#3C3273" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" />
     <g stroke="#3C3273" stroke-width="5" stroke-linecap="round">
-      <path d="M-68 12h34" />
-      <path d="M-70 20h38" />
-      <path d="M68 12h-34" />
-      <path d="M70 20h-38" />
+      <path d="M-70 0h36" />
+      <path d="M-72 12h40" />
+      <path d="M70 0h-36" />
+      <path d="M72 12h-40" />
     </g>
-    <circle cx="0" cy="30" r="28" fill="#FFACC5" opacity="0.6" />
-    <path d="M-28 40c18 14 38 14 56 0" fill="none" stroke="#3C3273" stroke-width="6" stroke-linecap="round" />
-    <g fill="#3C3273">
-      <circle cx="-16" cy="22" r="4" />
-      <circle cx="16" cy="22" r="4" />
+    <path d="M-30 56c18 18 60 18 78 0" fill="none" stroke="#3C3273" stroke-width="6" stroke-linecap="round" />
+    <g fill="#F5F0FF">
+      <ellipse cx="-28" cy="44" rx="18" ry="22" />
+      <ellipse cx="28" cy="44" rx="18" ry="22" />
     </g>
+    <circle cx="0" cy="40" r="8" fill="#3C3273" />
   </g>
   <circle cx="260" cy="52" r="14" fill="#FFFFFF" opacity="0.5" />
   <circle cx="244" cy="44" r="8" fill="#FFFFFF" opacity="0.35" />

--- a/assets/ushi.svg
+++ b/assets/ushi.svg
@@ -1,29 +1,35 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
   <rect width="320" height="240" fill="#2A9D8F" rx="28" />
-  <g transform="translate(160 150)">
-    <path d="M-110-40c30-30 70-46 110-46s80 16 110 46v70c0 36-32 66-110 66s-110-30-110-66v-70z" fill="#F7F2EE" />
-    <path d="M-90-30c16-18 42-34 90-34s74 16 90 34v54c0 24-26 44-90 44s-90-20-90-44v-54z" fill="#F0E0DA" />
+  <g transform="translate(160 138)">
+    <ellipse cx="0" cy="70" rx="96" ry="60" fill="#F7F2EE" />
+    <path d="M-92 68c-22 12-34 32-20 52 14 20 44 26 74 10" fill="#3F3D56" opacity="0.2" />
+    <path d="M92 68c22 12 34 32 20 52-14 20-44 26-74 10" fill="#3F3D56" opacity="0.2" />
+    <g fill="#F7F2EE">
+      <path d="M-74-14c-48-10-78-68-24-90 32-12 64 20 74 46" />
+      <path d="M74-14c48-10 78-68 24-90-32-12-64 20-74 46" />
+      <ellipse cx="0" cy="-18" rx="88" ry="72" />
+    </g>
     <g fill="#E09C5A">
-      <path d="M-84-80c-16 0-28 18-18 32l20 30 18-14-20-48z" />
-      <path d="M84-80c16 0 28 18 18 32l-20 30-18-14 20-48z" />
-    </g>
-    <ellipse cx="-44" cy="-22" rx="18" ry="22" fill="#3F3D56" />
-    <ellipse cx="44" cy="-22" rx="18" ry="22" fill="#3F3D56" />
-    <ellipse cx="0" cy="36" rx="72" ry="50" fill="#FCD4DC" />
-    <g fill="#3F3D56">
-      <circle cx="-26" cy="18" r="6" />
-      <circle cx="26" cy="18" r="6" />
-      <path d="M-22 42c12 10 34 10 46 0" fill="none" stroke="#3F3D56" stroke-width="6" stroke-linecap="round" />
+      <path d="M-96-62c-20-30 12-64 44-44l28 18-20 42z" />
+      <path d="M96-62c20-30-12-64-44-44l-28 18 20 42z" />
     </g>
     <g fill="#3F3D56">
-      <ellipse cx="-64" cy="0" rx="12" ry="20" />
-      <ellipse cx="64" cy="0" rx="12" ry="20" />
+      <path d="M-44-32c-24-14-52 4-40 28 8 18 26 26 40 30l12-42z" />
+      <path d="M44-32c24-14 52 4 40 28-8 18-26 26-40 30l-12-42z" />
+      <circle cx="-32" cy="-10" r="10" />
+      <circle cx="32" cy="-10" r="10" />
+      <path d="M-22 8c10 12 34 12 44 0" fill="none" stroke="#3F3D56" stroke-width="6" stroke-linecap="round" />
+      <path d="M-76 32c18 32 48 46 76 46s58-14 76-46" fill="none" stroke="#3F3D56" stroke-width="6" stroke-linecap="round" />
     </g>
-    <path d="M-34-74c-10-30 12-54 34-54s44 24 34 54c-6 18-22 22-34 22s-28-4-34-22z" fill="#F7F2EE" />
-    <g transform="translate(0 -66)" fill="#3F3D56">
-      <circle cx="-16" cy="0" r="6" />
-      <circle cx="16" cy="0" r="6" />
-      <path d="M-10 14c6 4 14 4 20 0" fill="none" stroke="#3F3D56" stroke-width="4" stroke-linecap="round" />
+    <g>
+      <ellipse cx="0" cy="40" rx="68" ry="50" fill="#FCD4DC" />
+      <ellipse cx="-22" cy="36" rx="14" ry="18" fill="#3F3D56" />
+      <ellipse cx="22" cy="36" rx="14" ry="18" fill="#3F3D56" />
+      <path d="M-24 56c12 10 36 10 48 0" fill="none" stroke="#3F3D56" stroke-width="6" stroke-linecap="round" />
+    </g>
+    <g fill="#3F3D56">
+      <path d="M-12 0c-28-14-58 20-38 42 18 20 42 12 62-2z" />
+      <path d="M12 0c28-14 58 20 38 42-18 20-42 12-62-2z" />
     </g>
   </g>
   <circle cx="54" cy="54" r="16" fill="#FDF6E4" opacity="0.65" />


### PR DESCRIPTION
## Summary
- replace the neko card artwork with a full cat face and whiskers that fill the existing canvas
- update the inu illustration to feature a recognizable dog with a muzzle, floppy ears, and body curves
- refresh the ushi drawing so the cow shows horns, a snout, and coat patches while keeping the background treatment

## Testing
- Viewed index.html in the browser

------
https://chatgpt.com/codex/tasks/task_e_68de291261fc8330acf87331529cd028