### PR TITLE
Add toggle to control hiragana tile speech playback

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,15 @@
         <div class="speech-area">
           <button
             type="button"
+            id="toggle-tile-audio-btn"
+            class="toggle-speech-btn"
+            aria-pressed="true"
+            aria-label="ひらがな選択時の読み上げを切り替える"
+          >
+            ひらがな読み上げ：<span id="tile-audio-status">オン</span>
+          </button>
+          <button
+            type="button"
             id="speak-btn"
             class="speak-btn"
             aria-label="選択中のことばを読み上げる"

--- a/main.js
+++ b/main.js
@@ -56,6 +56,7 @@ const state = {
   speechSupported: false,
   selectedWord: null,
   currentIllustrationSrc: null,
+  audioEnabledForTiles: true,
 };
 
 const audioState = {
@@ -81,6 +82,8 @@ const cardGrid = document.getElementById('card-grid');
 const speakButton = document.getElementById('speak-btn');
 const speechNotice = document.getElementById('speech-notice');
 const newProblemButton = document.getElementById('new-problem-btn');
+const tileAudioToggleButton = document.getElementById('toggle-tile-audio-btn');
+const tileAudioStatusText = document.getElementById('tile-audio-status');
 
 const illustrationContainer = illustration
   ? illustration.closest('.illustration')
@@ -145,6 +148,14 @@ function wireEvents() {
     });
   }
 
+  if (tileAudioToggleButton) {
+    updateTileAudioToggleUI();
+    tileAudioToggleButton.addEventListener('click', () => {
+      state.audioEnabledForTiles = !state.audioEnabledForTiles;
+      updateTileAudioToggleUI();
+    });
+  }
+
   if (newProblemButton) {
     newProblemButton.addEventListener('click', loadNewProblem);
   }
@@ -166,6 +177,33 @@ function updateSpeechSupportUI() {
     speakButton.removeAttribute('title');
     if (speechNotice) {
       speechNotice.hidden = false;
+    }
+  }
+
+  updateTileAudioToggleUI();
+}
+
+function updateTileAudioToggleUI() {
+  if (!tileAudioToggleButton) {
+    return;
+  }
+
+  const enabled = Boolean(state.audioEnabledForTiles);
+  const pressed = state.speechSupported && enabled;
+  tileAudioToggleButton.disabled = !state.speechSupported;
+  tileAudioToggleButton.setAttribute('aria-pressed', pressed ? 'true' : 'false');
+
+  if (!state.speechSupported) {
+    tileAudioToggleButton.title = '音声が利用できません';
+  } else {
+    tileAudioToggleButton.removeAttribute('title');
+  }
+
+  if (tileAudioStatusText) {
+    if (!state.speechSupported) {
+      tileAudioStatusText.textContent = '利用不可';
+    } else {
+      tileAudioStatusText.textContent = enabled ? 'オン' : 'オフ';
     }
   }
 }
@@ -240,7 +278,7 @@ function onCardClick(event) {
     return;
   }
 
-  if (state.speechSupported) {
+  if (state.speechSupported && state.audioEnabledForTiles) {
     speakWord(selectedWord);
   }
 


### PR DESCRIPTION
## Summary
- add a footer toggle to enable or disable automatic hiragana tile speech
- store the tile audio state and update the toggle text and aria attributes on click
- gate automatic speech playback based on the new state

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de2e89f3488330bc6b5ee9d3ee16d9