### PR TITLE
Add drop slot accuracy feedback and completion tracking

### DIFF
--- a/style.css
+++ b/style.css
@@ -232,6 +232,20 @@ button {
   color: var(--text);
 }
 
+.drop-slot.is-correct {
+  border-color: var(--correct);
+  border-style: solid;
+  background: rgba(46, 125, 50, 0.16);
+  color: var(--correct);
+}
+
+.drop-slot.is-incorrect {
+  border-color: var(--incorrect);
+  border-style: solid;
+  background: rgba(198, 40, 40, 0.15);
+  color: var(--incorrect);
+}
+
 .choice-card {
   list-style: none;
   border: 2px solid transparent;


### PR DESCRIPTION
## Summary
- add per-slot correctness evaluation in `fillDropSlot`, including audio feedback and descriptive aria labels
- highlight drop slots for correct and incorrect letters and reset styling appropriately
- detect when all slots are correct to play completion audio only once per completion

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68de58f602388330bd01bab0dd506654