### PR TITLE
Add speech playback to letter tiles

### DIFF
--- a/main.js
+++ b/main.js
@@ -177,6 +177,8 @@ function buildLetterTiles() {
     tile.setAttribute('aria-roledescription', 'ドラッグできるひらがなカード');
     tile.setAttribute('aria-grabbed', 'false');
     tile.textContent = '';
+    tile.addEventListener('click', handleTileClick);
+    tile.addEventListener('keydown', handleTileSpeechKeyDown);
     letterPool.appendChild(tile);
     return tile;
   });
@@ -349,6 +351,32 @@ function initializeDragAndDrop() {
   letterPool.addEventListener('dragover', handleDropTargetOver);
   letterPool.addEventListener('dragleave', handleDropTargetLeave);
   letterPool.addEventListener('drop', handleDropOnPool);
+}
+
+function handleTileClick(event) {
+  const tile = event.currentTarget;
+  if (!tile) {
+    return;
+  }
+
+  const letter = (tile.dataset.letter || tile.textContent || '').trim();
+  if (letter === '') {
+    return;
+  }
+
+  if (!(state.speechSupported && state.audioEnabledForTiles)) {
+    return;
+  }
+
+  speakWord(letter);
+}
+
+function handleTileSpeechKeyDown(event) {
+  if (event.key !== 'Enter' && event.key !== ' ') {
+    return;
+  }
+
+  handleTileClick(event);
 }
 
 function handleTileDragStart(event) {


### PR DESCRIPTION
## Summary
- add speech handlers on letter tiles to trigger audio when activated
- guard playback behind speech support, tile audio toggle, and tile content

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de58f182f48330bec6330d229d55db