### PR TITLE
Hide choices heading visually

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
         <p class="result" id="result-text" role="status" aria-live="polite"></p>
       </section>
       <section class="choices" aria-labelledby="choices-title">
-        <h2 id="choices-title">ことばをえらぶ</h2>
+        <h2 id="choices-title" class="sr-only">ことばをえらぶ</h2>
         <div class="card-grid" id="card-grid" role="list"></div>
         <div class="letter-play-area" aria-label="文字カードを並べ替えるエリア">
           <div


### PR DESCRIPTION
## Summary
- visually hide the choices section heading while keeping it accessible to screen readers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de612f3084833094f016960aea4f42