### PR TITLE
Enable illustration speech playback

### DIFF
--- a/main.js
+++ b/main.js
@@ -230,6 +230,33 @@ function wireEvents() {
     });
   }
 
+  if (illustration && state.speechSupported) {
+    const speakFromIllustration = () => {
+      if (!(state.speechSupported && state.audioEnabledForTiles)) {
+        return;
+      }
+
+      const targetWord = state.currentWord || state.selectedWord;
+      if (!targetWord) {
+        return;
+      }
+
+      speakWord(targetWord);
+    };
+
+    illustration.addEventListener('click', speakFromIllustration);
+    illustration.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        speakFromIllustration();
+      }
+    });
+
+    if (!illustration.hasAttribute('tabindex')) {
+      illustration.setAttribute('tabindex', '0');
+    }
+  }
+
   if (tileAudioToggleButton) {
     updateTileAudioToggleUI();
     tileAudioToggleButton.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add an illustration event handler so speech can be triggered directly from the prompt image
- guard the handler with the existing speech/toggle logic and fall back to whichever word is available

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68de61344c0c83309d49a4c065a287bf