### PR TITLE
Show solved word when letter slots complete

### DIFF
--- a/main.js
+++ b/main.js
@@ -613,9 +613,19 @@ function updateWordCompletionState() {
 
   if (isComplete && !state.wasWordCompleted) {
     state.wasWordCompleted = true;
+    if (wordDisplay && typeof state.currentWord === 'string') {
+      wordDisplay.textContent = state.currentWord;
+    }
+    setIllustrationFor(state.currentWord, { showCaption: true });
+    setResultText('せいかい！', true);
     playFeedbackSound(true);
   } else if (!isComplete && state.wasWordCompleted) {
     state.wasWordCompleted = false;
+    if (wordDisplay) {
+      wordDisplay.textContent = '？？';
+    }
+    setResultText('？？');
+    showIllustrationPreview();
   }
 }
 
@@ -721,10 +731,7 @@ function buildLetterCandidateSet(word) {
 function resetPrompt() {
   wordDisplay.textContent = '？？';
 
-  if (resultText) {
-    resultText.textContent = '';
-    resultText.style.color = 'var(--muted)';
-  }
+  setResultText('？？');
 }
 
 function pickRandomWord() {
@@ -911,7 +918,11 @@ function setResultText(message, isCorrect) {
   }
 
   resultText.textContent = message;
-  resultText.style.color = isCorrect ? 'var(--correct)' : 'var(--incorrect)';
+  if (typeof isCorrect === 'boolean') {
+    resultText.style.color = isCorrect ? 'var(--correct)' : 'var(--incorrect)';
+  } else {
+    resultText.style.color = 'var(--muted)';
+  }
 }
 
 function getIllustrationFor(word) {


### PR DESCRIPTION
## Summary
- update word completion checks to reveal the solved word, illustration caption, and a success message
- reset the prompt display and feedback back to the question state when slots are cleared or a new puzzle loads
- allow neutral feedback styling so the question state uses the muted color

## Testing
- python /invocations/hwagxzwd/script.py

------
https://chatgpt.com/codex/tasks/task_e_68de6135b7a88330bdae4d540bf9767a