### PR TITLE
Hide word cards and adjust spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -140,7 +140,7 @@ button {
 }
 
 .card-grid {
-  display: grid;
+  display: none;
   gap: 1rem;
   grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
 }
@@ -153,6 +153,10 @@ button {
   border-radius: 20px;
   background-color: rgba(255, 255, 255, 0.85);
   box-shadow: 0 16px 36px rgba(46, 61, 123, 0.12);
+}
+
+.choices .letter-play-area {
+  margin-top: 0;
 }
 
 .letter-pool {


### PR DESCRIPTION
## Summary
- hide the word card grid by disabling its display
- reset the letter play area's top margin within the choices section so the layout remains tight

## Testing
- Manual QA: Loaded `index.html` in a browser via `python3 -m http.server 8000` and confirmed the card row is hidden and the layout is still correct


------
https://chatgpt.com/codex/tasks/task_e_68df3612b6b483308a959509d99fd59d