### PR TITLE
Add white background behind illustration images

### DIFF
--- a/style.css
+++ b/style.css
@@ -86,6 +86,7 @@ button {
   width: 100%;
   height: auto;
   border-radius: 24px;
+  background-color: #fff;
   box-shadow: 0 20px 40px rgba(43, 58, 101, 0.1);
 }
 


### PR DESCRIPTION
## Summary
- ensure illustration images render on a white background to avoid transparent artifacts

## Testing
- Manual: Viewed index.html in the browser to confirm white background behind the illustration

------
https://chatgpt.com/codex/tasks/task_e_68e08cc4534083309fcf8b47c61a1899