### PR TITLE
Fix illustration overlay styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -83,7 +83,7 @@ button {
   text-align: center;
 }
 
-.illustration img {
+#word-illustration {
   width: 100%;
   height: auto;
   border-radius: 24px;
@@ -99,6 +99,8 @@ button {
   height: auto;
   max-width: 100%;
   border-radius: 24px;
+  background-color: transparent;
+  box-shadow: none;
   pointer-events: none;
   opacity: 0;
   transform: scale(0.96);


### PR DESCRIPTION
## Summary
- scope the card styling to the base illustration image only
- ensure the celebration overlay remains transparent without a drop shadow

## Testing
- Manually reloaded the app in the browser to verify the overlay transparency

------
https://chatgpt.com/codex/tasks/task_e_68e0d626d4c48330bd1d5d7606c84afd