### PR TITLE
Reset illustration placeholder before loading next problem

### DIFF
--- a/main.js
+++ b/main.js
@@ -486,17 +486,21 @@ function loadNewProblem() {
     return;
   }
 
-  state.currentWord = pickRandomWord();
+  const nextWord = pickRandomWord();
 
   state.selectedWord = null;
   state.wasWordCompleted = false;
   hideCelebrationOverlay();
   resetPrompt();
-  showIllustrationPreview();
-  renderDropSlots();
-  renderLetterCandidates(state.currentWord);
+  setIllustrationFor(null, { showCaption: true });
 
-  const choices = buildChoiceSet(state.currentWord, WORDS);
+  state.currentWord = nextWord;
+
+  showIllustrationPreview(nextWord);
+  renderDropSlots();
+  renderLetterCandidates(nextWord);
+
+  const choices = buildChoiceSet(nextWord, WORDS);
   cardButtons.forEach((button, index) => {
     const choice = choices[index];
     const word =
@@ -1313,15 +1317,15 @@ function revealCurrentWord() {
   setIllustrationFor(state.currentWord, { showCaption: true });
 }
 
-function showIllustrationPreview() {
+function showIllustrationPreview(word = state.currentWord) {
   hideCelebrationOverlay();
 
-  if (!state.currentWord) {
+  if (!word) {
     setIllustrationFor(null, { showCaption: true });
     return;
   }
 
-  setIllustrationFor(state.currentWord, { showCaption: false });
+  setIllustrationFor(word, { showCaption: false });
 }
 
 function normalizeIllustrationOptions(options) {

--- a/style.css
+++ b/style.css
@@ -89,6 +89,11 @@ button {
   border-radius: 24px;
   background-color: #fff;
   box-shadow: 0 20px 40px rgba(43, 58, 101, 0.1);
+  transition: opacity 0.25s ease;
+}
+
+.illustration[data-preview='true'] #word-illustration {
+  opacity: 0.82;
 }
 
 .illustration-overlay {


### PR DESCRIPTION
## Summary
- reset the illustration to the placeholder before revealing a newly selected word
- update preview and candidate rendering to use the freshly chosen word
- soften the preview state with an opacity transition so the placeholder swap is smoother

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68e2300035b48330860ba1c28444e6ac