### PR TITLE
Simplify placeholder SVG background

### DIFF
--- a/assets/placeholder.svg
+++ b/assets/placeholder.svg
@@ -1,11 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240">
-  <rect width="320" height="240" fill="#E0E0E0" rx="28" />
-  <g transform="translate(160 120)">
-    <path d="M-28-20c0-26 18-44 48-44 24 0 46 16 46 40 0 22-14 34-26 44-8 6-16 12-16 24v6h-20v-8c0-16 10-26 22-36 8-6 16-14 16-24 0-12-10-20-22-20-18 0-26 12-26 26h-22z" fill="#B0B0B0" opacity="0.7" />
-    <circle cx="2" cy="64" r="12" fill="#B0B0B0" opacity="0.7" />
-  </g>
-  <g fill="#fff" opacity="0.6">
-    <circle cx="76" cy="60" r="14" />
-    <circle cx="242" cy="52" r="10" />
-  </g>
+  <rect width="320" height="240" fill="#ffffff" />
 </svg>


### PR DESCRIPTION
## Summary
- replace the placeholder illustration with a solid white rectangle
- keep the placeholder asset referenced for empty illustration states

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2338b324883309dd4a50362673620