### PR TITLE
Ensure illustration preview retains placeholder

### DIFF
--- a/main.js
+++ b/main.js
@@ -1325,7 +1325,7 @@ function showIllustrationPreview(word = state.currentWord) {
     return;
   }
 
-  setIllustrationFor(word, { showCaption: false });
+  setIllustrationFor(null, { showCaption: true });
 }
 
 function normalizeIllustrationOptions(options) {


### PR DESCRIPTION
## Summary
- keep the placeholder illustration visible during previews instead of showing the real image

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2354284c08330ad50796eb339d994